### PR TITLE
show max date month instead of end of year

### DIFF
--- a/projects/ng-persian-datepicker/src/lib/ng-persian-datepicker.component.ts
+++ b/projects/ng-persian-datepicker/src/lib/ng-persian-datepicker.component.ts
@@ -324,7 +324,7 @@ export class NgPersianDatepickerComponent implements OnInit, OnDestroy {
 
   setViewDate(): void {
     if (!this.dateValueDefined()) {
-      this.viewDate = this.dateMax ? Jalali.timestamp(this.dateMax, false).endOf('year') : this.today.clone();
+      this.viewDate = this.dateMax ? Jalali.timestamp(this.dateMax, false) : this.today.clone();
     } else {
       this.viewDate = this.dateMax && this.selectedDate!.valueOf() > this.dateMax.valueOf() ?
         Jalali.timestamp(this.dateMax, false) : this.selectedDate!.clone();


### PR DESCRIPTION
Hi, 
When `dateMax` input, has been set and the `dateInitValue` input has been set to be false, then the date picker opens at the end of the year. 
The problem is most of those dates are disabled because they are more than `dateMax` so a better approach would be to open the calendar at the `dateMax` month.